### PR TITLE
add mime-type for mjpeg serializer

### DIFF
--- a/sensorhub-service-video/src/main/java/org/sensorhub/impl/service/sos/video/MJPEGSerializer.java
+++ b/sensorhub-service-video/src/main/java/org/sensorhub/impl/service/sos/video/MJPEGSerializer.java
@@ -27,6 +27,8 @@ import org.vast.ows.OWSRequest;
 
 public class MJPEGSerializer implements ISOSCustomSerializer
 {
+    public static String MJPEG_MIME_TYPE = "video/x-motion-jpeg";
+
     private static final String MIME_TYPE_MULTIPART = "multipart/x-mixed-replace; boundary=--myboundary"; 
     private static final byte[] MIME_BOUNDARY_JPEG = new String("--myboundary\r\nContent-Type: image/jpeg\r\nContent-Length: ").getBytes();
     private static final byte[] END_MIME = new byte[] {0xD, 0xA, 0xD, 0xA};


### PR DESCRIPTION
When I was manually adding `customFormats` to a `SOSServiceConfig` I noticed `MP4Serializer` had its mime-type as a static string. When I tried to do the same with MJPEGSerializer I noticed it wasn't there. Thought I'd add it